### PR TITLE
Implement prefetching and instances.

### DIFF
--- a/lib/puppet/provider/chronos_job/chronos_job.rb
+++ b/lib/puppet/provider/chronos_job/chronos_job.rb
@@ -1,21 +1,87 @@
-require 'httparty'
-require 'json'
 Puppet::Type.type(:chronos_job).provide(:default) do
+
+  # I've had issues with lazy loading of providers in the past where requirements
+  # for the provider to function are best defined inside the provider as opposed
+  # to the standard Ruby practice.  Allows for you to be able to install httparty
+  # on the same run as the provider is synced.
+  require 'httparty'
+  require 'json'
 
   desc "Implements creating Chronos jobs through its REST api."
 
+  mk_resource_methods
+
+  @default_target = 'http://localhost:4400'
+
+  class << self
+    attr_accessor :default_target
+  end
+
+  def self.targets(resources = nil)
+    targets = []
+    # First get the default target
+    targets << self.default_target
+
+    if resources
+      resources.each do |name, resource|
+        if value = resource[:host]
+          targets << value
+        end
+      end
+    end
+
+    targets.uniq.compact
+  end
+
+  def self.instances(resources = nil)
+
+    instances = []
+
+    ltargets = targets(resources)
+
+    ltargets.each do |target|
+      jobs = HTTParty.get("#{target}/scheduler/jobs")
+
+      jobs.each do |job|
+        job = {
+          :name                  => job['name'],
+          :async                 => job['async'],
+          :command               => job['command'],
+          :environment_variables => jog['environmentVariables'],
+          :epsilon               => job['epsilon'],
+          :owner                 => job['owner'],
+          :retries               => job['retries'],
+          :cpus                  => job['cpus'],
+          :disk                  => job['disk'],
+          :mem                   => job['mem']
+        }
+
+        instances << new(job)
+      end
+    end
+    instances
+  end
+
+  def self.prefetch(resources)
+    instances(resources).each do |prov|
+      if res = resources[prov.name.to_s]
+        res.provider = prov
+      end
+    end
+  end
+
   def create
     job = {
-    "name" => resource[:name],
-    "async" =>  resource[:async],
-    "command" => resource[:command],
-    "environmentVariables" => resource[:environment_variables],
-    "epsilon" => resource[:epsilon],
-    "owner" => resource[:owner],
-    "retries" => resource[:retries],
-    "cpus" => resource[:cpus],
-    "disk" => resource[:disk],
-    "mem" => resource[:mem],
+      'name'                 => resource[:name],
+      'async'                => resource[:async],
+      'command'              => resource[:command],
+      'environmentVariables' => resource[:environment_variables],
+      'epsilon'              => resource[:epsilon],
+      'owner'                => resource[:owner],
+      'retries'              => resource[:retries],
+      'cpus'                 => resource[:cpus],
+      'disk'                 => resource[:disk],
+      'mem'                  => resource[:mem],
     }
 
     headers = {
@@ -42,18 +108,7 @@ Puppet::Type.type(:chronos_job).provide(:default) do
   end
 
   def exists?
-    begin
-      response = HTTParty.get("#{resource[:host]}/scheduler/jobs")
-      body = JSON.parse(response.body)
-      body.each do |job|
-        if resource[:name] == job['name']
-          return true
-        end
-      end
-      return false
-    rescue HTTParty::Error
-      raise Puppet::Error, "Error while connecting to Chronos host #{resource[:host]}"
-    end
+    !(@property_hash[:ensure] == :absent or @property_hash.empty?)
   end
 
   def destroy

--- a/lib/puppet/type/chronos_job.rb
+++ b/lib/puppet/type/chronos_job.rb
@@ -1,126 +1,127 @@
+require 'puppet/property/boolean'
 Puppet::Type.newtype(:chronos_job) do
 
-    @doc = "Manage creation/deletion of Chronos jobs."
+  @doc = "Manage creation/deletion of Chronos jobs."
 
-    ensurable
+  ensurable
 
-    newparam(:name, :namevar => true) do
-        desc "The name of the Chronos job."
-    end
+  newparam(:name, :namevar => true) do
+    desc "The name of the Chronos job."
+  end
 
-    newparam(:host) do
-        desc "The host/port to the chronos host. Defaults to localhost."
-        defaultto 'http://localhost:4400'
-    end
+  newparam(:host) do
+    desc "The host/port to the chronos host. Defaults to localhost."
+    defaultto 'http://localhost:4400'
+  end
 
-    newparam(:command) do
-        desc "The command to execute in the job."
-        validate do |val|
-            unless val.is_a? String
-                raise ArgumentError, "epsilon parameter must be a String, got value of type #{val.class}"
-            end
-        end
-    end
-
-    newparam(:environment_variables) do
-        desc "Optionally create parent Chronos jobs."
-        validate do |val|
-          unless val.is_a? Array
-            raise ArgumentError, "environment_variables parameter must be an Array, got value of type #{val.class}"
-          end
-        end
-    end
-
-
-    newparam(:job_schedule) do
-        desc "The scheduling for the job, in ISO8601 format."
-        validate do |val|
-            unless val.is_a? String
-                raise ArgumentError, "schedule parameter must be a String, got value of type #{val.class}"
-            end
-        end
-    end
-
-    newparam(:schedule_timezone) do
-        desc "The time zone name to use when scheduling the job."
-        validate do |val|
-            if not val.is_a? String
-                raise ArgumentError, "schedule_timezone parameter must be a String, got value of type #{val.class}"
-            end
-        end
-    end
-
-    newparam(:epsilon) do
-        desc "The interval to run the job on, in ISO8601 duration format."
-        validate do |val|
-            unless val.is_a? String
-                raise ArgumentError, "epsilon parameter must be a String, got value of type #{val.class}"
-            end
-        end
-    end
-
-    newparam(:owner) do
-        desc "The email address of the person or persons interested in the job status."
-        validate do |val|
-            unless val.is_a? String
-                raise ArgumentError, "owner parameter must be a String, got value of type #{val.class}"
-            end
-        end
-    end
-
-    newparam(:async, :boolean => true, :parent => Puppet::Parameter::Boolean) do
-        desc "Whether or not the job runs in the background."
-    end
-
-    newparam(:parents) do
-        desc "Optionally create parent Chronos jobs."
-        validate do |val|
-          unless val.is_a? Array
-            raise ArgumentError, "parents parameter must be an Array, got value of type #{val.class}"
-          end
-        end
-    end
-
-    newparam(:retries) do
-      desc "Number of times to retry job execution after a failure."
-      validate do |val|
-        unless val.is_a? Fixnum
-          raise ArgumentError, "retries parameter must be a Fixnum, got value of type #{val.class}"
-        end
+  newproperty(:command) do
+    desc "The command to execute in the job."
+    validate do |val|
+      unless val.is_a? String
+        raise ArgumentError, "epsilon parameter must be a String, got value of type #{val.class}"
       end
     end
+  end
 
-    newparam(:cpus) do
-      desc "Amount of cpu shares to allocate to a job."
-      defaultto 0.1
-      validate do |val|
-        unless val.is_a? Float
-          raise ArgumentError, "cpus parameter must be a Float, got value of type #{val.class}"
-        end
+  newproperty(:environment_variables) do
+    desc "Optionally create parent Chronos jobs."
+    validate do |val|
+      unless val.is_a? Array
+        raise ArgumentError, "environment_variables parameter must be an Array, got value of type #{val.class}"
       end
     end
+  end
 
-    newparam(:disk) do
-      desc "Amount of disk to allocate to a job."
-      defaultto 256
-      validate do |val|
-        unless val.is_a? Fixnum
-          raise ArgumentError, "cpus parameter must be a Fixnum, got value of type #{val.class}"
-        end
+
+  newproperty(:job_schedule) do
+    desc "The scheduling for the job, in ISO8601 format."
+    validate do |val|
+      unless val.is_a? String
+        raise ArgumentError, "schedule parameter must be a String, got value of type #{val.class}"
       end
     end
+  end
 
-    newparam(:mem) do
-      desc "Amount of disk to allocate to a job."
-      defaultto 64
-      validate do |val|
-        unless val.is_a? Fixnum
-          raise ArgumentError, "cpus parameter must be a Fixnum, got value of type #{val.class}"
-        end
+  newparam(:schedule_timezone) do
+    desc "The time zone name to use when scheduling the job."
+    defaultto 'UTC'
+    validate do |val|
+      if not val.is_a? String
+        raise ArgumentError, "schedule_timezone parameter must be a String, got value of type #{val.class}"
       end
     end
+  end
 
-    autorequire(:chronos_job) do
-      parent_jobs = self[:parents]
+  newproperty(:epsilon) do
+    desc "The interval to run the job on, in ISO8601 duration format."
+    validate do |val|
+      unless val.is_a? String
+        raise ArgumentError, "epsilon parameter must be a String, got value of type #{val.class}"
+      end
     end
+  end
+
+  newproperty(:owner) do
+    desc "The email address of the person or persons interested in the job status."
+    # Should we validate against http://www.ex-parrot.com/~pdw/Mail-RFC822-Address.html...?
+    validate do |val|
+      unless val.is_a? String
+        raise ArgumentError, "owner parameter must be a String, got value of type #{val.class}"
+      end
+    end
+  end
+
+  newproperty(:async, :boolean => true, :parent => Puppet::Property::Boolean) do
+    desc "Whether or not the job runs in the background."
+  end
+
+  newproperty(:parents) do
+    desc "Optionally associate with parent Chronos job(s)."
+    munge do |value|
+      value.to_a
+    end
+  end
+
+  newproperty(:retries) do
+    desc "Number of times to retry job execution after a failure."
+    validate do |val|
+      unless val.is_a? Fixnum
+        raise ArgumentError, "owner parameter must be a String, got value of type #{val.class}"
+      end
+    end
+  end
+
+  newproperty(:cpus) do
+    desc "Amount of cpu shares to allocate to a job."
+    defaultto 0.1
+    validate do |val|
+      unless val.is_a? Float
+        raise ArgumentError, "cpus parameter must be a Float, got value of type #{val.class}"
+      end
+    end
+  end
+
+  newproperty(:disk) do
+    desc "Amount of disk to allocate to a job."
+    defaultto 256
+    validate do |val|
+      unless val.is_a? Fixnum
+        raise ArgumentError, "cpus parameter must be a Fixnum, got value of type #{val.class}"
+      end
+    end
+  end
+
+  newproperty(:mem) do
+    desc "Amount of disk to allocate to a job."
+    defaultto 64
+    validate do |val|
+      unless val.is_a? Fixnum
+        raise ArgumentError, "cpus parameter must be a Fixnum, got value of type #{val.class}"
+      end
+    end
+  end
+
+  autorequire(:chronos_job) do
+    parent_jobs = self[:parents]
+  end
 end


### PR DESCRIPTION
  This commit adds self.instances and self.prefetch methods so that
  "pupept resources chronos_job" works and @property_hash is available
  for.

  Without this we have pull ALL jobs from chronos everytime we want to
  check the existance of a single job.

  ...also fixes tabs to be Ruby two instead of Python four.
