### PR TITLE
Fix providers

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,7 @@ class chronos (
 
   if $manage_package_deps {
     $gem_provider = $::puppetversion ? {
-      /Puppet Enterprise/ => 'pe-gem',
+      /Puppet Enterprise/ => 'pe_gem',
       default             => 'gem',
     }
 

--- a/spec/classes/chronos_spec.rb
+++ b/spec/classes/chronos_spec.rb
@@ -44,8 +44,8 @@ describe 'chronos' do
               facts.merge!({:puppetversion => '3.6.2 (Puppet Enterprise 3.3.0)'})
             end
 
-            it { should contain_package('httparty').with_provider('pe-gem') }
-            it { should contain_package('json').with_provider('pe-gem') }
+            it { should contain_package('httparty').with_provider('pe_gem') }
+            it { should contain_package('json').with_provider('pe_gem') }
           end
 
           context 'with default params' do


### PR DESCRIPTION
- Solves issue https://github.com/puppetlabs/puppetlabs-chronos/issues/13 with pe_gem
- Chronos service is managed by upstart. I added option $service_provider to reflect that.
