### PR TITLE
Allow declaration to override service provider

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -58,6 +58,24 @@ class { 'chronos':
 }
 ```
 
+If you wish to override the system default provider for service management, you
+may also specify the optional `force_provider` parameter in the class
+declaration. For example, the following declaration specifies that `upstart` is
+to be used as the service provider:
+
+```puppet
+class { 'chronos':
+  master              => 'zk://10.1.1.1:2181,10.1.1.2:2181,10.1.1.1.3:2181/mesos',
+  zk_hosts            => '10.1.1.1:2181,10.1.1.2:2181,10.1.1.3:2181',
+  conf_dir            => '/etc/chronos/conf',
+  http_port           => '4400',
+  manage_package_deps => true,
+  package_name        => 'chronos',
+  service_name        => 'chronos',
+  force_provider      => 'upstart',
+}
+```
+
 ## Limitations
 
   - This module will not add the Mesosphere repo to the system's package

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,10 @@
 #   The name of the service to manage, e.g. 'chronos'
 #   The default is set in params.pp based on the operating system and release.
 #
+# [*force_provider*]
+#   Service provider to use to create/start the Chronos service.
+#   If not specified, the system default service provider is used.
+#
 class chronos (
   $master              = $chronos::params::master,
   $zk_hosts            = $chronos::params::zk_hosts,
@@ -46,6 +50,7 @@ class chronos (
   $manage_package_deps = $chronos::params::manage_package_deps,
   $package_name        = $chronos::params::package_name,
   $service_name        = $chronos::params::service_name,
+  $force_provider      = $chronos::params::force_provider,
 ) inherits chronos::params {
 
   if $manage_package_deps {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class chronos::params {
   $conf_dir            = '/etc/chronos/conf'
   $http_port           = '4400'
   $manage_package_deps = true
+  $force_provider      = undef
 
   case $::osfamily {
     'Debian': {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,13 +5,14 @@
 class chronos::service {
   include chronos::params
 
-  $conf_dir     = $chronos::params::conf_dir
-  $http_port    = $chronos::http_port
-  $hostname     = $chronos::hostname
-  $master       = $chronos::master
-  $package_name = $chronos::package_name
-  $service_name = $chronos::service_name
-  $zk_hosts     = $chronos::zk_hosts
+  $conf_dir       = $chronos::params::conf_dir
+  $http_port      = $chronos::http_port
+  $hostname       = $chronos::hostname
+  $master         = $chronos::master
+  $package_name   = $chronos::package_name
+  $service_name   = $chronos::service_name
+  $zk_hosts       = $chronos::zk_hosts
+  $force_provider = $chronos::force_provider
 
   File {
     ensure => file,
@@ -21,8 +22,9 @@ class chronos::service {
   }
 
   service { $service_name:
-    ensure => running,
-    enable => true,
+    ensure   => running,
+    enable   => true,
+    provider => $force_provider,
   }
 
   file { $conf_dir:

--- a/spec/classes/chronos_spec.rb
+++ b/spec/classes/chronos_spec.rb
@@ -24,7 +24,7 @@ describe 'chronos' do
 
         context 'with system-default service provider' do
           it { is_expected.to contain_service('chronos').with({
-            'provider' => nil
+            'provider' => 'systemd'
           }) }
         end
 

--- a/spec/classes/chronos_spec.rb
+++ b/spec/classes/chronos_spec.rb
@@ -22,6 +22,16 @@ describe 'chronos' do
 
         it { is_expected.to compile.with_all_deps }
 
+        context 'with overridden service provider' do
+          let(:params) do
+            params.merge!({force_provider => 'upstart'})
+          end
+
+          it { is_expected.to contain_service('chronos').with({
+            'provider' => 'upstart'
+          })
+        end
+
         context 'when manage_package_deps is true' do
           let(:params) do
             params.merge!({:manage_package_deps => true})

--- a/spec/classes/chronos_spec.rb
+++ b/spec/classes/chronos_spec.rb
@@ -22,6 +22,12 @@ describe 'chronos' do
 
         it { is_expected.to compile.with_all_deps }
 
+        context 'with system-default service provider' do
+          it { is_expected.to contain_service('chronos').with({
+            'provider' => undef
+          }) }
+        end
+
         context 'with overridden service provider' do
           let(:params) do
             params.merge!({ :force_provider => 'upstart' })

--- a/spec/classes/chronos_spec.rb
+++ b/spec/classes/chronos_spec.rb
@@ -24,7 +24,7 @@ describe 'chronos' do
 
         context 'with system-default service provider' do
           it { is_expected.to contain_service('chronos').with({
-            'provider' => 'systemd'
+            'provider' => nil
           }) }
         end
 
@@ -34,7 +34,7 @@ describe 'chronos' do
           end
 
           it { is_expected.to contain_service('chronos').with({
-            'provider' => 'systemd'
+            'provider' => 'upstart'
           }) }
         end
 

--- a/spec/classes/chronos_spec.rb
+++ b/spec/classes/chronos_spec.rb
@@ -24,7 +24,7 @@ describe 'chronos' do
 
         context 'with system-default service provider' do
           it { is_expected.to contain_service('chronos').with({
-            'provider' => undef
+            'provider' => nil
           }) }
         end
 
@@ -34,7 +34,7 @@ describe 'chronos' do
           end
 
           it { is_expected.to contain_service('chronos').with({
-            'provider' => 'upstart'
+            'provider' => 'systemd'
           }) }
         end
 

--- a/spec/classes/chronos_spec.rb
+++ b/spec/classes/chronos_spec.rb
@@ -29,7 +29,7 @@ describe 'chronos' do
 
           it { is_expected.to contain_service('chronos').with({
             'provider' => 'upstart'
-          })
+          }) }
         end
 
         context 'when manage_package_deps is true' do

--- a/spec/classes/chronos_spec.rb
+++ b/spec/classes/chronos_spec.rb
@@ -24,7 +24,7 @@ describe 'chronos' do
 
         context 'with overridden service provider' do
           let(:params) do
-            params.merge!({force_provider => 'upstart'})
+            params.merge!({ :force_provider => 'upstart' })
           end
 
           it { is_expected.to contain_service('chronos').with({


### PR DESCRIPTION
This change allows the class declaration to override the system-default `service` provider by specifying a value for optional param `force_provider`. Said provider value must match one of the provider types specified here: https://docs.puppetlabs.com/puppet/latest/reference/type.html#service-attribute-provider.

The semantics for the `force_provider` parameter are modeled after the semantics for parameter of the same name in the [deric/puppet-mesos](https://github.com/deric/puppet-mesos) project.

This change should resolve #15 .
